### PR TITLE
ggstat: support uncomparable types in agg

### DIFF
--- a/ggstat/agg.go
+++ b/ggstat/agg.go
@@ -128,6 +128,9 @@ func checkConst(t *table.Table, col string) bool {
 	if v.Len() <= 1 {
 		return true
 	}
+	if !v.Type().Elem().Comparable() {
+		return false
+	}
 	elem := v.Index(0).Interface()
 	for i, l := 1, v.Len(); i < l; i++ {
 		if elem != v.Index(i).Interface() {


### PR DESCRIPTION
agg currently panics when faced with an uncomparable column type (e.g. a slice)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aclements/go-gg/7)
<!-- Reviewable:end -->
