### PR TITLE
gg: implement LayerArea

### DIFF
--- a/gg/layer.go
+++ b/gg/layer.go
@@ -145,6 +145,40 @@ func (l LayerPaths) apply(p *Plot, sort bool) {
 	}, p.Data().Tables()})
 }
 
+// LayerArea shades the area between two columns with a polygon. It is
+// useful in conjunction with ggstat.AggMax and ggstat.AggMin for
+// drawing the extents of data.
+type LayerArea struct {
+	// X names the column that defines the input of each point. If
+	// this is empty, it defaults to the first column.
+	X string
+
+	// Upper and Lower name columns that define the range of
+	// response to shade. If either is "", it defaults to a
+	// constant 0 value.
+	Upper, Lower string
+
+	// Fill names a column that defines the fill color of each
+	// path. If Fill is "", it defaults to 50% opacity
+	// black. Otherwise, the data is grouped by Fill.
+	Fill string
+}
+
+func (l LayerArea) Apply(p *Plot) {
+	defaultCols(p, &l.X)
+	if l.Fill != "" {
+		p.GroupBy(l.Fill)
+	}
+	defer p.Save().Restore()
+	p = p.SortBy(l.X)
+	p.marks = append(p.marks, plotMark{&markArea{
+		p.use("x", l.X),
+		p.use("y", l.Upper),
+		p.use("y", l.Lower),
+		p.use("fill", l.Fill),
+	}, p.Data().Tables()})
+}
+
 // LayerPoints layers a point mark at each data point.
 type LayerPoints struct {
 	// X and Y name columns that define input and response of each

--- a/gg/mark.go
+++ b/gg/mark.go
@@ -59,6 +59,39 @@ func (m *markPath) mark(env *renderEnv, canvas *svg.SVG) {
 	drawPath(canvas, xs, ys, stroke, fill)
 }
 
+type markArea struct {
+	x, upper, lower, fill *scaledData
+}
+
+func reversed(data []float64) []float64 {
+	var rev []float64
+	for i := len(data) - 1; i >= 0; i-- {
+		rev = append(rev, data[i])
+	}
+	return rev
+}
+
+func (m *markArea) mark(env *renderEnv, canvas *svg.SVG) {
+	xs := env.get(m.x).([]float64)
+	upper := make([]float64, len(xs))
+	if m.upper != nil {
+		upper = env.get(m.upper).([]float64)
+	}
+	lower := make([]float64, len(xs))
+	if m.lower != nil {
+		lower = env.get(m.lower).([]float64)
+	}
+	var fill color.Color = color.RGBA{0, 0, 0, 128}
+	if m.fill != nil {
+		fill = env.getFirst(m.fill).(color.Color)
+	}
+
+	xs = append(xs, reversed(xs)...)
+	ys := append(upper, reversed(lower)...)
+
+	drawPath(canvas, xs, ys, color.Transparent, fill)
+}
+
 type markSteps struct {
 	dir StepMode
 


### PR DESCRIPTION
LayerArea shades the area between two columns. It is useful in
conjunction with ggstat.AggMax and ggstat.AggMin for drawing the extents
of data.
